### PR TITLE
refactor: is-free -> is-chargeable

### DIFF
--- a/app/Controllers/Http/EventController.js
+++ b/app/Controllers/Http/EventController.js
@@ -68,7 +68,7 @@ class EventController {
    *                   type: string
    *                 comment:
    *                   type: string
-   *                 isFree:
+   *                 isChargeable:
    *                   type: boolean
    *                 isClosed:
    *                   type: boolean
@@ -93,7 +93,7 @@ class EventController {
       'event.maxPeople',
       'event.title',
       'event.comment',
-      'event.isFree',
+      'event.isChargeable',
       'event.isClosed'
     ])
     const createdEvent = await Event.create(event)
@@ -173,7 +173,7 @@ class EventController {
    *                   type: string
    *                 comment:
    *                   type: string
-   *                 isFree:
+   *                 isChargeable:
    *                   type: boolean
    *                 isClosed:
    *                   type: boolean
@@ -197,7 +197,7 @@ class EventController {
       'event.maxPeople',
       'event.title',
       'event.comment',
-      'event.isFree',
+      'event.isChargeable',
       'event.isClosed'
     ])
     eventToUpdate.merge(event)

--- a/app/Models/Event.js
+++ b/app/Models/Event.js
@@ -20,7 +20,7 @@ const Model = use('Model')
  *          type: string
  *        comment:
  *          type: string
- *        isFree:
+ *        isChargeable:
  *          type: boolean
  *        isClosed:
  *          type: boolean
@@ -35,7 +35,7 @@ const Model = use('Model')
  *        - endAt
  *        - title
  *        - comment
- *        - isFree
+ *        - isChargeable
  *        - isClosed
  */
 class Event extends Model {

--- a/app/Validators/Event.js
+++ b/app/Validators/Event.js
@@ -8,7 +8,7 @@ class Event {
       'event.maxPeople': 'required|number',
       'event.title': 'required|string',
       'event.comment': 'required|string',
-      'event.isFree': 'required|boolean',
+      'event.isChargeable': 'required|boolean',
       'event.isClosed': 'required|boolean'
     }
   }

--- a/database/factory.js
+++ b/database/factory.js
@@ -49,7 +49,7 @@ Factory.blueprint('App/Models/Event', async (faker) => {
     maxPeople: faker.integer({ min: 1, max: 50 }),
     title: faker.last(),
     comment: faker.first(),
-    isFree: faker.bool(),
+    isChargeable: faker.bool(),
     isClosed: faker.bool()
   }
 })

--- a/database/migrations/1615841974103_events_schema.js
+++ b/database/migrations/1615841974103_events_schema.js
@@ -12,7 +12,7 @@ class EventsSchema extends Schema {
       table.integer('maxPeople')
       table.string('title').notNullable()
       table.text('comment').notNullable()
-      table.boolean('isFree').notNullable().defaultTo(true)
+      table.boolean('isChargeable').notNullable().defaultTo(true)
       table.boolean('isClosed').notNullable().defaultTo(false)
       table.timestamps()
     })

--- a/test/functional/event.spec.js
+++ b/test/functional/event.spec.js
@@ -31,7 +31,7 @@ test('get list of events', async ({ client, assert }) => {
 
   response.assertStatus(200)
   assert.equal(response.body[0].isClosed, event.isClosed)
-  assert.equal(response.body[0].isFree, event.isFree)
+  assert.equal(response.body[0].isChargeable, event.isChargeable)
   assert.equal(response.body[0].maxPeople, event.maxPeople)
   assert.equal(response.body[0].title, event.title)
   assert.equal(response.body[0].comment, event.comment)
@@ -54,7 +54,7 @@ test('get detail of a event', async ({ client, assert }) => {
 
   response.assertStatus(200)
   assert.equal(response.body.isClosed, event.isClosed)
-  assert.equal(response.body.isFree, event.isFree)
+  assert.equal(response.body.isChargeable, event.isChargeable)
   assert.equal(response.body.maxPeople, event.maxPeople)
   assert.equal(response.body.title, event.title)
   assert.equal(response.body.comment, event.comment)
@@ -94,7 +94,7 @@ test('create a event as volunteer', async ({ client, assert }) => {
 
   response.assertStatus(201)
   assert.equal(response.body.isClosed, event.isClosed)
-  assert.equal(response.body.isFree, event.isFree)
+  assert.equal(response.body.isChargeable, event.isChargeable)
   assert.equal(response.body.maxPeople, event.maxPeople)
   assert.equal(response.body.title, event.title)
   assert.equal(response.body.comment, event.comment)
@@ -137,7 +137,7 @@ test('update an basic-service as volunteer', async ({ client, assert }) => {
 
   response.assertStatus(200)
   assert.equal(response.body.isClosed, event.isClosed)
-  assert.equal(response.body.isFree, event.isFree)
+  assert.equal(response.body.isChargeable, event.isChargeable)
   assert.equal(response.body.maxPeople, event.maxPeople)
   assert.equal(response.body.title, 'whatever')
   assert.equal(response.body.comment, event.comment)
@@ -175,7 +175,7 @@ test('delete a event as volunteer', async ({ client, assert }) => {
 
   response.assertStatus(200)
   assert.equal(response.body.isClosed, event.isClosed)
-  assert.equal(response.body.isFree, event.isFree)
+  assert.equal(response.body.isChargeable, event.isChargeable)
   assert.equal(response.body.maxPeople, event.maxPeople)
   assert.equal(response.body.title, event.title)
   assert.equal(response.body.comment, event.comment)


### PR DESCRIPTION
@quentinbt Cette MR est une proposition de changement pour la clé `isFree`en `isChargeable`, car dans les demandes métier sur Trello et dans les maquettes, la checkbox affiche si l'évenement est payant ou non.